### PR TITLE
Update build.rs

### DIFF
--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut config = Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
+
 
     // Print current directory
     println!("Current dir: {:?}", env::current_dir()?);


### PR DESCRIPTION
Protocol Buffers (protoc) compiler did not have the --experimental_allow_proto3_optional flag enabled, which is required for proto3 optional fields, which I have enabled for this pull request. 